### PR TITLE
Added working scripts for Perlmutter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 HSL = "34c5aeac-e683-54a6-a0e9-6e0fdc586c50"
 HSL_jll = "017b0a0e-03f4-516a-9b91-836bbd1904dd"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 MadNLPGPU = "d72a61cc-809d-412f-99be-fd81f4b8a598"
@@ -13,4 +14,4 @@ PowerModels = "c36e90e8-916a-50a6-bd94-075b64ef4655"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 
 [sources]
-HSL_jll = {path = "../HSL_jll.jl"}
+HSL_jll = {path = "/global/cfs/cdirs/amsc004/REPOS/HSL_jll.jl"}

--- a/acopf_gen_slurm_chunks.jl
+++ b/acopf_gen_slurm_chunks.jl
@@ -91,7 +91,7 @@ function resolve_instances(instances_arg::String)
     return replace.(filter(endswith(".m"), readdir(joinpath(artifact"PGLib_opf", "pglib-opf-23.07"))), ".m" => "")
 end
 
-function build_work(instances::Vector{String}, n_scenarios::Int, chunk_size::Int)
+function build_work(instances::AbstractVector{<:AbstractString}, n_scenarios::Int, chunk_size::Int)
     work = Vector{Tuple{String,Int,Int,Int}}()
     for inst in instances
         n_chunks = ceil(Int, n_scenarios / chunk_size)
@@ -140,169 +140,166 @@ function save_checkpoint(root::String, inst::String, completed::Set{Int}, total_
         JSON.print(io, Dict(
             "completed_chunks" => collect(completed),
             "total_chunks" => total_chunks,
-            "updated_at" => Dates.format(Dates.now(), Dates.RFC3339)
+            "updated_at" => Dates.format(Dates.now(), Dates.ISODateTimeFormat)
         ))
     end
     mv(tmp, ckpt_file; force=true)
 end
 
-function main()
-    opts = parse_cli()
-    instances = resolve_instances(opts[:instances])
-    procid = parse(Int, get(ENV, "SLURM_PROCID", "0"))
-    ntasks = parse(Int, get(ENV, "SLURM_NTASKS", "1"))
+opts = parse_cli()
+instances = resolve_instances(opts[:instances])
+procid = parse(Int, get(ENV, "SLURM_PROCID", "0"))
+ntasks = parse(Int, get(ENV, "SLURM_NTASKS", "1"))
 
-    all_work = build_work(instances, opts[:n_scenarios], opts[:chunk_size])
-    if isempty(all_work)
-        @info "No work to schedule."
-        return
-    end
-
-    my_work = [w for (i, w) in enumerate(all_work) if ((i - 1) % ntasks) == procid]
-    if isempty(my_work)
-        @info "Task $procid has no assigned work (ntasks=$ntasks)."
-        return
-    end
-
-    total_chunks = ceil(Int, opts[:n_scenarios] / opts[:chunk_size])
-    completed_map = Dict{String,Set{Int}}()
-
-    addprocs(opts[:nprocs])
-
-    pglib_path = joinpath(artifact"PGLib_opf", "pglib-opf-23.07")
-
-    @everywhere begin
-        using MadNLP
-        using MadNLPHSL
-        using PowerModels
-        using Ipopt
-        using JuMP
-        using Random
-        using HDF5
-        include("acopf_model.jl")
-        include("perturbations.jl")
-        include("hdf5_writer.jl")
-
-        function solve_scenario(base_network, scenario_id, p_range, q_range, SOLVER)
-            power_balance_relaxation = false
-            line_limit_relaxation = false
-
-            network = deepcopy(base_network)
-            perturb_loads_separate!(network, p_range, q_range, scenario_id)
-
-            pm = instantiate_model(network, ACPPowerModel,
-                pm -> build_opf_with_slacks(pm,
-                    power_balance_relaxation=false,
-                    line_limit_relaxation=false
-                )
-            )
-
-            if SOLVER == :ipopt
-                JuMP.set_optimizer(pm.model, Ipopt.Optimizer)
-            elseif SOLVER == :madnlp
-                JuMP.set_optimizer(pm.model, ()->MadNLP.Optimizer(linear_solver=Ma27Solver, print_level=MadNLP.WARN))
-            else
-                error("Unsupported solver on worker: $(SOLVER)")
-            end
-
-            result = optimize_model!(pm)
-
-            if result["termination_status"] != MOI.LOCALLY_SOLVED
-                pm = instantiate_model(network, ACPPowerModel,
-                    pm -> build_opf_with_slacks(pm,
-                        power_balance_relaxation=true,
-                        line_limit_relaxation=true
-                    )
-                )
-                power_balance_relaxation = true
-                line_limit_relaxation = true
-
-                if SOLVER == :ipopt
-                    JuMP.set_optimizer(pm.model, Ipopt.Optimizer)
-                elseif SOLVER == :madnlp
-                    JuMP.set_optimizer(pm.model, ()->MadNLP.Optimizer(linear_solver=Ma27Solver, print_level=MadNLP.WARN))
-                else
-                    error("Unsupported solver on worker: $(SOLVER)")
-                end
-                result = optimize_model!(pm)
-                if result["termination_status"] != MOI.LOCALLY_SOLVED
-                    return nothing
-                end
-            end
-
-            total_power_slack = 0.0
-            if power_balance_relaxation && haskey(result, "solution")
-                for (_, bus) in result["solution"]["bus"]
-                    if haskey(bus, "p_slack_pos")
-                        total_power_slack += bus["p_slack_pos"] + bus["p_slack_neg"] + bus["q_slack_pos"] + bus["q_slack_neg"]
-                    end
-                end
-            end
-
-            total_line_slack = 0.0
-            if line_limit_relaxation && haskey(result, "solution")
-                for (_, branch) in result["solution"]["branch"]
-                    if haskey(branch, "s_slack")
-                        total_line_slack += branch["s_slack"]
-                    end
-                end
-            end
-
-            return (
-                id = scenario_id,
-                network = network,
-                result = result,
-                obj = result["objective"],
-                time = result["solve_time"],
-                status = string(result["termination_status"]),
-                power_slack = total_power_slack,
-                line_slack = total_line_slack
-            )
-        end
-    end
-
-    @everywhere p_rng = $(opts[:p_range])
-    @everywhere q_rng = $(opts[:q_range])
-
-    PowerModels.silence()
-
-    for (inst, chunk_idx, start_idx, end_idx) in my_work
-        case_file = joinpath(pglib_path, string(inst, ".m"))
-        instance_output_dir = joinpath(opts[:output_dir], inst)
-        mkpath(instance_output_dir)
-
-        completed = get!(completed_map, inst) do
-            opts[:force] ? Set{Int}() : load_completed(opts[:output_dir], inst)
-        end
-
-        chunk_filename = joinpath(instance_output_dir, "chunk_$(lpad(chunk_idx + 1, 4, '0')).h5")
-        if opts[:resume] && !opts[:force] && (chunk_idx in completed || isfile(chunk_filename))
-            println("[$inst] Chunk $(chunk_idx+1) already done, skipping.")
-            push!(completed, chunk_idx)
-            save_checkpoint(opts[:output_dir], inst, completed, total_chunks)
-            continue
-        end
-
-        base_network = PowerModels.parse_file(case_file)
-        @everywhere shared_network = $base_network
-
-        println("Task $procid handling $inst chunk $(chunk_idx+1) scenarios $start_idx:$end_idx (ntasks=$ntasks)")
-
-        scenario_ids = start_idx:end_idx
-        chunk_results = pmap(i -> solve_scenario(shared_network, i, p_rng, q_rng, opts[:solver]), scenario_ids)
-        successful_results = filter(!isnothing, chunk_results)
-
-        if isempty(successful_results)
-            @warn "[$inst] No successful solves for chunk $chunk_idx (scenarios $start_idx:$end_idx)"
-            continue
-        end
-
-        write_chunk_to_hdf5(chunk_filename, successful_results)
-        println("[$inst] Chunk $(chunk_idx+1) complete: wrote $(length(successful_results)) / $(length(chunk_results)) scenarios")
-
-        push!(completed, chunk_idx)
-        save_checkpoint(opts[:output_dir], inst, completed, total_chunks)
-    end
+all_work = build_work(instances, opts[:n_scenarios], opts[:chunk_size])
+if isempty(all_work)
+@info "No work to schedule."
+return
 end
 
-main()
+my_work = [w for (i, w) in enumerate(all_work) if ((i - 1) % ntasks) == procid]
+if isempty(my_work)
+@info "Task $procid has no assigned work (ntasks=$ntasks)."
+return
+end
+
+total_chunks = ceil(Int, opts[:n_scenarios] / opts[:chunk_size])
+completed_map = Dict{String,Set{Int}}()
+
+addprocs(opts[:nprocs])
+
+pglib_path = joinpath(artifact"PGLib_opf", "pglib-opf-23.07")
+
+@everywhere begin
+using MadNLP
+using MadNLPHSL
+using PowerModels
+using Ipopt
+using JuMP
+using Random
+using HDF5
+include("acopf_model.jl")
+include("perturbations.jl")
+include("hdf5_writer.jl")
+
+function solve_scenario(base_network, scenario_id, p_range, q_range, SOLVER)
+    power_balance_relaxation = false
+    line_limit_relaxation = false
+
+    network = deepcopy(base_network)
+    perturb_loads_separate!(network, p_range, q_range, scenario_id)
+
+    pm = instantiate_model(network, ACPPowerModel,
+	pm -> build_opf_with_slacks(pm,
+	    power_balance_relaxation=false,
+	    line_limit_relaxation=false
+	)
+    )
+
+    if SOLVER == :ipopt
+	JuMP.set_optimizer(pm.model, Ipopt.Optimizer)
+    elseif SOLVER == :madnlp
+	JuMP.set_optimizer(pm.model, ()->MadNLP.Optimizer(linear_solver=Ma27Solver, print_level=MadNLP.WARN))
+    else
+	error("Unsupported solver on worker: $(SOLVER)")
+    end
+
+    result = optimize_model!(pm)
+
+    if result["termination_status"] != MOI.LOCALLY_SOLVED
+	pm = instantiate_model(network, ACPPowerModel,
+	    pm -> build_opf_with_slacks(pm,
+		power_balance_relaxation=true,
+		line_limit_relaxation=true
+	    )
+	)
+	power_balance_relaxation = true
+	line_limit_relaxation = true
+
+	if SOLVER == :ipopt
+	    JuMP.set_optimizer(pm.model, Ipopt.Optimizer)
+	elseif SOLVER == :madnlp
+	    JuMP.set_optimizer(pm.model, ()->MadNLP.Optimizer(linear_solver=Ma27Solver, print_level=MadNLP.WARN))
+	else
+	    error("Unsupported solver on worker: $(SOLVER)")
+	end
+	result = optimize_model!(pm)
+	if result["termination_status"] != MOI.LOCALLY_SOLVED
+	    return nothing
+	end
+    end
+
+    total_power_slack = 0.0
+    if power_balance_relaxation && haskey(result, "solution")
+	for (_, bus) in result["solution"]["bus"]
+	    if haskey(bus, "p_slack_pos")
+		total_power_slack += bus["p_slack_pos"] + bus["p_slack_neg"] + bus["q_slack_pos"] + bus["q_slack_neg"]
+	    end
+	end
+    end
+
+    total_line_slack = 0.0
+    if line_limit_relaxation && haskey(result, "solution")
+	for (_, branch) in result["solution"]["branch"]
+	    if haskey(branch, "s_slack")
+		total_line_slack += branch["s_slack"]
+	    end
+	end
+    end
+
+    return (
+	id = scenario_id,
+	network = network,
+	result = result,
+	obj = result["objective"],
+	time = result["solve_time"],
+	status = string(result["termination_status"]),
+	power_slack = total_power_slack,
+	line_slack = total_line_slack
+    )
+end
+end
+
+@everywhere p_rng = $(opts[:p_range])
+@everywhere q_rng = $(opts[:q_range])
+
+PowerModels.silence()
+
+for (inst, chunk_idx, start_idx, end_idx) in my_work
+case_file = joinpath(pglib_path, string(inst, ".m"))
+instance_output_dir = joinpath(opts[:output_dir], inst)
+mkpath(instance_output_dir)
+
+completed = get!(completed_map, inst) do
+    opts[:force] ? Set{Int}() : load_completed(opts[:output_dir], inst)
+end
+
+chunk_filename = joinpath(instance_output_dir, "chunk_$(lpad(chunk_idx + 1, 4, '0')).h5")
+if opts[:resume] && !opts[:force] && (chunk_idx in completed || isfile(chunk_filename))
+    println("[$inst] Chunk $(chunk_idx+1) already done, skipping.")
+    push!(completed, chunk_idx)
+    save_checkpoint(opts[:output_dir], inst, completed, total_chunks)
+    continue
+end
+
+base_network = PowerModels.parse_file(case_file)
+@everywhere shared_network = $base_network
+
+println("Task $procid handling $inst chunk $(chunk_idx+1) scenarios $start_idx:$end_idx (ntasks=$ntasks)")
+
+scenario_ids = start_idx:end_idx
+chunk_results = pmap(i -> solve_scenario(shared_network, i, p_rng, q_rng, opts[:solver]), scenario_ids)
+successful_results = filter(!isnothing, chunk_results)
+
+if isempty(successful_results)
+    @warn "[$inst] No successful solves for chunk $chunk_idx (scenarios $start_idx:$end_idx)"
+    continue
+end
+
+write_chunk_to_hdf5(chunk_filename, successful_results)
+println("[$inst] Chunk $(chunk_idx+1) complete: wrote $(length(successful_results)) / $(length(chunk_results)) scenarios")
+
+push!(completed, chunk_idx)
+save_checkpoint(opts[:output_dir], inst, completed, total_chunks)
+end
+

--- a/acopf_gen_slurm_chunks.jl
+++ b/acopf_gen_slurm_chunks.jl
@@ -1,0 +1,308 @@
+#!/usr/bin/env julia
+# Slurm-friendly ACOPF generator: dynamically assigns instances + chunks to tasks.
+# Launch with multiple tasks (e.g., srun -N <nodes> --ntasks=<tasks> --cpus-per-task=64),
+# without Slurm arrays. Work is round-robin partitioned across tasks so any number of
+# nodes can cover an arbitrary number of instances/chunks.
+
+using Pkg.Artifacts
+using Distributed
+using ProgressMeter
+using HDF5
+using ArgParse
+using JSON
+using Dates
+
+function parse_cli()
+    s = ArgParseSettings()
+    @add_arg_table s begin
+        "--solver"
+            help = "Solver to use: ipopt, madnlp"
+            arg_type = String
+            default = "madnlp"
+        "--instances"
+            help = "Comma-separated PGLib instances (without .m); defaults to all from artifact"
+            arg_type = String
+            default = ""
+        "--nprocs"
+            help = "Number of worker processes to add on each node"
+            arg_type = Int
+            default = Sys.CPU_THREADS
+        "--n_scenarios"
+            help = "Scenarios per instance"
+            arg_type = Int
+            default = 10000
+        "--chunk_size"
+            help = "Scenarios per chunk"
+            arg_type = Int
+            default = 200
+        "--output_dir"
+            help = "Root directory to write results into (per-instance subdirs are created)"
+            arg_type = String
+            default = ""
+        "--p_range"
+            help = "Active power perturbation range as a,b"
+            arg_type = String
+            default = "0.9,1.1"
+        "--q_range"
+            help = "Reactive power perturbation range as a,b"
+            arg_type = String
+            default = "0.9,1.1"
+        "--resume"
+            help = "Skip chunks already completed (checkpoint/existing files)"
+            arg_type = Bool
+            default = true
+        "--force"
+            help = "Ignore checkpoints and redo all chunks"
+            arg_type = Bool
+            default = false
+    end
+
+    parsed = parse_args(s)
+
+    opts = Dict{Symbol,Any}()
+    opts[:solver] = Symbol(lowercase(parsed["solver"]))
+    opts[:instances] = parsed["instances"]
+    opts[:nprocs] = parsed["nprocs"]
+    opts[:n_scenarios] = parsed["n_scenarios"]
+    opts[:chunk_size] = parsed["chunk_size"]
+    opts[:output_dir] = parsed["output_dir"]
+    pr = split(parsed["p_range"], ",")
+    opts[:p_range] = (parse(Float64, pr[1]), parse(Float64, pr[2]))
+    qr = split(parsed["q_range"], ",")
+    opts[:q_range] = (parse(Float64, qr[1]), parse(Float64, qr[2]))
+    opts[:resume] = parsed["resume"]
+    opts[:force] = parsed["force"]
+
+    if opts[:output_dir] == ""
+        opts[:output_dir] = joinpath("results")
+    end
+
+    return opts
+end
+
+function resolve_instances(instances_arg::String)
+    if instances_arg != ""
+        return split(instances_arg, ",")
+    end
+    env_instances = get(ENV, "INSTANCES", "")
+    if env_instances != ""
+        return split(env_instances, ",")
+    end
+    return replace.(filter(endswith(".m"), readdir(joinpath(artifact"PGLib_opf", "pglib-opf-23.07"))), ".m" => "")
+end
+
+function build_work(instances::Vector{String}, n_scenarios::Int, chunk_size::Int)
+    work = Vector{Tuple{String,Int,Int,Int}}()
+    for inst in instances
+        n_chunks = ceil(Int, n_scenarios / chunk_size)
+        for chunk_idx in 0:(n_chunks - 1)
+            start_idx = chunk_idx * chunk_size + 1
+            end_idx = min((chunk_idx + 1) * chunk_size, n_scenarios)
+            push!(work, (inst, chunk_idx, start_idx, end_idx))
+        end
+    end
+    return work
+end
+
+checkpoint_path(root::String, inst::String) = joinpath(root, inst, "checkpoint.json")
+
+function load_completed(root::String, inst::String)
+    done = Set{Int}()
+    inst_dir = joinpath(root, inst)
+    if isdir(inst_dir)
+        for f in readdir(inst_dir; join=true)
+            m = match(r"chunk_(\d{4})\.h5", basename(f))
+            m === nothing && continue
+            push!(done, parse(Int, m.captures[1]) - 1)
+        end
+    end
+    ckpt_file = checkpoint_path(root, inst)
+    if isfile(ckpt_file)
+        try
+            data = JSON.parsefile(ckpt_file)
+            if haskey(data, "completed_chunks")
+                for c in data["completed_chunks"]
+                    push!(done, Int(c))
+                end
+            end
+        catch e
+            @warn "Failed to read checkpoint for $inst: $e"
+        end
+    end
+    return done
+end
+
+function save_checkpoint(root::String, inst::String, completed::Set{Int}, total_chunks::Int)
+    ckpt_file = checkpoint_path(root, inst)
+    mkpath(dirname(ckpt_file))
+    tmp = ckpt_file * ".tmp"
+    open(tmp, "w") do io
+        JSON.print(io, Dict(
+            "completed_chunks" => collect(completed),
+            "total_chunks" => total_chunks,
+            "updated_at" => Dates.format(Dates.now(), Dates.RFC3339)
+        ))
+    end
+    mv(tmp, ckpt_file; force=true)
+end
+
+function main()
+    opts = parse_cli()
+    instances = resolve_instances(opts[:instances])
+    procid = parse(Int, get(ENV, "SLURM_PROCID", "0"))
+    ntasks = parse(Int, get(ENV, "SLURM_NTASKS", "1"))
+
+    all_work = build_work(instances, opts[:n_scenarios], opts[:chunk_size])
+    if isempty(all_work)
+        @info "No work to schedule."
+        return
+    end
+
+    my_work = [w for (i, w) in enumerate(all_work) if ((i - 1) % ntasks) == procid]
+    if isempty(my_work)
+        @info "Task $procid has no assigned work (ntasks=$ntasks)."
+        return
+    end
+
+    total_chunks = ceil(Int, opts[:n_scenarios] / opts[:chunk_size])
+    completed_map = Dict{String,Set{Int}}()
+
+    addprocs(opts[:nprocs])
+
+    pglib_path = joinpath(artifact"PGLib_opf", "pglib-opf-23.07")
+
+    @everywhere begin
+        using MadNLP
+        using MadNLPHSL
+        using PowerModels
+        using Ipopt
+        using JuMP
+        using Random
+        using HDF5
+        include("acopf_model.jl")
+        include("perturbations.jl")
+        include("hdf5_writer.jl")
+
+        function solve_scenario(base_network, scenario_id, p_range, q_range, SOLVER)
+            power_balance_relaxation = false
+            line_limit_relaxation = false
+
+            network = deepcopy(base_network)
+            perturb_loads_separate!(network, p_range, q_range, scenario_id)
+
+            pm = instantiate_model(network, ACPPowerModel,
+                pm -> build_opf_with_slacks(pm,
+                    power_balance_relaxation=false,
+                    line_limit_relaxation=false
+                )
+            )
+
+            if SOLVER == :ipopt
+                JuMP.set_optimizer(pm.model, Ipopt.Optimizer)
+            elseif SOLVER == :madnlp
+                JuMP.set_optimizer(pm.model, ()->MadNLP.Optimizer(linear_solver=Ma27Solver, print_level=MadNLP.WARN))
+            else
+                error("Unsupported solver on worker: $(SOLVER)")
+            end
+
+            result = optimize_model!(pm)
+
+            if result["termination_status"] != MOI.LOCALLY_SOLVED
+                pm = instantiate_model(network, ACPPowerModel,
+                    pm -> build_opf_with_slacks(pm,
+                        power_balance_relaxation=true,
+                        line_limit_relaxation=true
+                    )
+                )
+                power_balance_relaxation = true
+                line_limit_relaxation = true
+
+                if SOLVER == :ipopt
+                    JuMP.set_optimizer(pm.model, Ipopt.Optimizer)
+                elseif SOLVER == :madnlp
+                    JuMP.set_optimizer(pm.model, ()->MadNLP.Optimizer(linear_solver=Ma27Solver, print_level=MadNLP.WARN))
+                else
+                    error("Unsupported solver on worker: $(SOLVER)")
+                end
+                result = optimize_model!(pm)
+                if result["termination_status"] != MOI.LOCALLY_SOLVED
+                    return nothing
+                end
+            end
+
+            total_power_slack = 0.0
+            if power_balance_relaxation && haskey(result, "solution")
+                for (_, bus) in result["solution"]["bus"]
+                    if haskey(bus, "p_slack_pos")
+                        total_power_slack += bus["p_slack_pos"] + bus["p_slack_neg"] + bus["q_slack_pos"] + bus["q_slack_neg"]
+                    end
+                end
+            end
+
+            total_line_slack = 0.0
+            if line_limit_relaxation && haskey(result, "solution")
+                for (_, branch) in result["solution"]["branch"]
+                    if haskey(branch, "s_slack")
+                        total_line_slack += branch["s_slack"]
+                    end
+                end
+            end
+
+            return (
+                id = scenario_id,
+                network = network,
+                result = result,
+                obj = result["objective"],
+                time = result["solve_time"],
+                status = string(result["termination_status"]),
+                power_slack = total_power_slack,
+                line_slack = total_line_slack
+            )
+        end
+    end
+
+    @everywhere p_rng = $(opts[:p_range])
+    @everywhere q_rng = $(opts[:q_range])
+
+    PowerModels.silence()
+
+    for (inst, chunk_idx, start_idx, end_idx) in my_work
+        case_file = joinpath(pglib_path, string(inst, ".m"))
+        instance_output_dir = joinpath(opts[:output_dir], inst)
+        mkpath(instance_output_dir)
+
+        completed = get!(completed_map, inst) do
+            opts[:force] ? Set{Int}() : load_completed(opts[:output_dir], inst)
+        end
+
+        chunk_filename = joinpath(instance_output_dir, "chunk_$(lpad(chunk_idx + 1, 4, '0')).h5")
+        if opts[:resume] && !opts[:force] && (chunk_idx in completed || isfile(chunk_filename))
+            println("[$inst] Chunk $(chunk_idx+1) already done, skipping.")
+            push!(completed, chunk_idx)
+            save_checkpoint(opts[:output_dir], inst, completed, total_chunks)
+            continue
+        end
+
+        base_network = PowerModels.parse_file(case_file)
+        @everywhere shared_network = $base_network
+
+        println("Task $procid handling $inst chunk $(chunk_idx+1) scenarios $start_idx:$end_idx (ntasks=$ntasks)")
+
+        scenario_ids = start_idx:end_idx
+        chunk_results = pmap(i -> solve_scenario(shared_network, i, p_rng, q_rng, opts[:solver]), scenario_ids)
+        successful_results = filter(!isnothing, chunk_results)
+
+        if isempty(successful_results)
+            @warn "[$inst] No successful solves for chunk $chunk_idx (scenarios $start_idx:$end_idx)"
+            continue
+        end
+
+        write_chunk_to_hdf5(chunk_filename, successful_results)
+        println("[$inst] Chunk $(chunk_idx+1) complete: wrote $(length(successful_results)) / $(length(chunk_results)) scenarios")
+
+        push!(completed, chunk_idx)
+        save_checkpoint(opts[:output_dir], inst, completed, total_chunks)
+    end
+end
+
+main()

--- a/analyze_hdf5_stats.jl
+++ b/analyze_hdf5_stats.jl
@@ -1,0 +1,69 @@
+#!/usr/bin/env julia
+# Basic aggregation for ACOPF HDF5 outputs: solve time, objective, slack, status counts.
+
+using HDF5
+using Statistics
+using Printf
+
+function read_scenarios(path::String)
+    # Use a flexible vector type so we can push NamedTuples read from HDF5.
+    # Previously `Tuple[]` caused a MethodError when pushing NamedTuples.
+    records = Vector{Any}()
+    h5open(path, "r") do f
+        for name in keys(f)
+            startswith(name, "scenario_") || continue
+            md = f[name]["metadata"]
+            attrs = attributes(md)
+            objective   = read(attrs["objective"])
+            solve_time  = read(attrs["solve_time"])
+            status      = String(read(attrs["status"]))
+            p_slack     = read(attrs["total_power_slack"])
+            l_slack     = read(attrs["total_line_slack"])
+            push!(records, (
+                file = path,
+                scenario = name,
+                objective = objective,
+                solve_time = solve_time,
+                status = status,
+                power_slack = p_slack,
+                line_slack = l_slack
+            ))
+        end
+    end
+    return records
+end
+
+function summarize(records)
+    if isempty(records)
+        println("No scenarios found.")
+        return
+    end
+    times   = [r.solve_time for r in records]
+    objs    = [r.objective for r in records]
+    pslack  = [r.power_slack for r in records]
+    lslack  = [r.line_slack for r in records]
+
+    status_counts = Dict{String,Int}()
+    for r in records
+        status_counts[r.status] = get(status_counts, r.status, 0) + 1
+    end
+
+    @printf "Total scenarios: %d across %d files\n" length(records) length(unique(r.file for r in records))
+    @printf "Solve time (s): mean=%.3f median=%.3f min=%.3f max=%.3f\n" mean(times) median(times) minimum(times) maximum(times)
+    @printf "Objective:       mean=%.6g median=%.6g min=%.6g max=%.6g\n" mean(objs) median(objs) minimum(objs) maximum(objs)
+    @printf "Power slack:     mean=%.3e max=%.3e\n" mean(pslack) maximum(pslack)
+    @printf "Line slack:      mean=%.3e max=%.3e\n" mean(lslack) maximum(lslack)
+    println("Status counts:")
+    for (k,v) in sort(collect(status_counts); by=x->x[1])
+        println("  $(rpad(k, 20)): $v")
+    end
+end
+
+function main(args)
+    isempty(args) && error("Provide one or more HDF5 files (globs expanded by shell).")
+    files = collect(args)
+    all_records = reduce(vcat, (read_scenarios(f) for f in files); init=Tuple[])
+    summarize(all_records)
+end
+
+main(ARGS)

--- a/scripts/perlmutter_acopf_10k_cpu.sl
+++ b/scripts/perlmutter_acopf_10k_cpu.sl
@@ -1,24 +1,21 @@
 #!/bin/bash
 #SBATCH -C cpu
-#SBATCH -A <account>
-#SBATCH -q <qos>
-#SBATCH -t 04:00:00
-#SBATCH -N 2
+#SBATCH -A amsc004
+#SBATCH -q regular
+#SBATCH -t 00:30:00
+#SBATCH -N 128
 #SBATCH --ntasks-per-node=1
-#SBATCH --cpus-per-task=128
+#SBATCH --cpus-per-task=64
 #SBATCH --job-name=acopf_10k_cpu
-#SBATCH --output=logs/acopf_10k_cpu_%A_%a.out
-#SBATCH --error=logs/acopf_10k_cpu_%A_%a.err
-#SBATCH --array=0-0
-
-# Perlmutter CPU job to generate ACOPF data with acopf_gen_parallel.jl.
-# Edit SBATCH lines (account/qos/time/nodes/array) before submitting.
-# If INSTANCES is unset, this script will derive all PGLib instances from Artifacts.toml.
+#SBATCH --output=logs/acopf_10k_cpu_%j.out
+#SBATCH --error=logs/acopf_10k_cpu_%j.err
 
 set -euo pipefail
+module load julia
 
 # Move to repo root (assumes script lives in scripts/)
-cd "$(dirname "$0")/.."
+cd $SLURM_SUBMIT_DIR
+mkdir -p logs
 
 # Resolve instance list from env or Artifacts.toml
 if [ -z "${INSTANCES:-}" ]; then
@@ -26,46 +23,29 @@ if [ -z "${INSTANCES:-}" ]; then
 fi
 
 SCENARIOS_PER_INSTANCE=${SCENARIOS_PER_INSTANCE:-10000}
-CHUNK_SIZE=${CHUNK_SIZE:-200}
-NPROCS=${NPROCS:-32}
+CHUNK_SIZE=${CHUNK_SIZE:-500}
+NPROCS=${NPROCS:-64}
 SOLVER=${SOLVER:-madnlp}
-OUTPUT_ROOT=${OUTPUT_ROOT:-${SCRATCH:-/tmp}/exagrid}
+OUTPUT_ROOT=${OUTPUT_ROOT:-${SCRATCH:-/tmp}/exagrid/pglib_opf/10K}
+RESUME=${RESUME:-true}
+FORCE=${FORCE:-false}
 
-IFS=',' read -r -a INST_ARRAY <<< "$INSTANCES"
-if [ ${#INST_ARRAY[@]} -eq 0 ]; then
-  echo "No instances provided via INSTANCES or Artifacts.toml." >&2
-  exit 1
-fi
+SRUN_NTASKS=${SLURM_NTASKS:-1}
 
-if [ -z "${SLURM_ARRAY_TASK_ID:-}" ]; then
-  echo "SLURM_ARRAY_TASK_ID is not set; submit with --array=0-$(( ${#INST_ARRAY[@]} - 1 ))." >&2
-  exit 1
-fi
-
-if [ "$SLURM_ARRAY_TASK_ID" -ge "${#INST_ARRAY[@]}" ]; then
-  echo "Array index $SLURM_ARRAY_TASK_ID exceeds instance list (${#INST_ARRAY[@]})." >&2
-  exit 1
-fi
-
-INSTANCE=${INST_ARRAY[$SLURM_ARRAY_TASK_ID]}
-OUTPUT_DIR=${OUTPUT_ROOT}/${INSTANCE}/10k
-mkdir -p "$OUTPUT_DIR" logs
-
-export JULIA_NUM_THREADS=${NPROCS}
-
-srun --nodes=${SLURM_NNODES:-1} \
-     --ntasks=1 \
+srun --ntasks=${SRUN_NTASKS} \
      --ntasks-per-node=1 \
      --cpus-per-task=${NPROCS} \
-  julia --project acopf_gen_parallel.jl \
-    --instance=${INSTANCE} \
+  julia --project acopf_gen_slurm_chunks.jl \
+    --instances=${INSTANCES} \
     --n_scenarios=${SCENARIOS_PER_INSTANCE} \
     --chunk_size=${CHUNK_SIZE} \
     --nprocs=${NPROCS} \
-    --output_dir=${OUTPUT_DIR} \
-    --solver=${SOLVER}
+    --output_dir=${OUTPUT_ROOT} \
+    --solver=${SOLVER} \
+    --resume=${RESUME} \
+    --force=${FORCE}
 
 # Edit SBATCH account/qos/time/nodes and set array (example for 4 instances):
-# sbatch --array=0-3 scripts/perlmutter_acopf_10k_cpu.sl
+# sbatch scripts/perlmutter_acopf_10k_cpu.sl
 # Run for a specific set of instances (override INSTANCES):
-# INSTANCES="case89pegase,case162_ieee_dtc" sbatch --array=0-1 scripts/perlmutter_acopf_10k_cpu.sl
+# INSTANCES="case89pegase,case162_ieee_dtc" sbatch scripts/perlmutter_acopf_200_cpu.sl

--- a/scripts/perlmutter_acopf_10k_cpu.sl
+++ b/scripts/perlmutter_acopf_10k_cpu.sl
@@ -1,0 +1,71 @@
+#!/bin/bash
+#SBATCH -C cpu
+#SBATCH -A <account>
+#SBATCH -q <qos>
+#SBATCH -t 04:00:00
+#SBATCH -N 2
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=128
+#SBATCH --job-name=acopf_10k_cpu
+#SBATCH --output=logs/acopf_10k_cpu_%A_%a.out
+#SBATCH --error=logs/acopf_10k_cpu_%A_%a.err
+#SBATCH --array=0-0
+
+# Perlmutter CPU job to generate ACOPF data with acopf_gen_parallel.jl.
+# Edit SBATCH lines (account/qos/time/nodes/array) before submitting.
+# If INSTANCES is unset, this script will derive all PGLib instances from Artifacts.toml.
+
+set -euo pipefail
+
+# Move to repo root (assumes script lives in scripts/)
+cd "$(dirname "$0")/.."
+
+# Resolve instance list from env or Artifacts.toml
+if [ -z "${INSTANCES:-}" ]; then
+  INSTANCES=$(julia --project -e 'using Pkg.Artifacts; base = joinpath(artifact"PGLib_opf", "pglib-opf-23.07"); names = replace.(filter(endswith(".m"), readdir(base)), ".m" => ""); print(join(names, ","))')
+fi
+
+SCENARIOS_PER_INSTANCE=${SCENARIOS_PER_INSTANCE:-10000}
+CHUNK_SIZE=${CHUNK_SIZE:-200}
+NPROCS=${NPROCS:-32}
+SOLVER=${SOLVER:-madnlp}
+OUTPUT_ROOT=${OUTPUT_ROOT:-${SCRATCH:-/tmp}/exagrid}
+
+IFS=',' read -r -a INST_ARRAY <<< "$INSTANCES"
+if [ ${#INST_ARRAY[@]} -eq 0 ]; then
+  echo "No instances provided via INSTANCES or Artifacts.toml." >&2
+  exit 1
+fi
+
+if [ -z "${SLURM_ARRAY_TASK_ID:-}" ]; then
+  echo "SLURM_ARRAY_TASK_ID is not set; submit with --array=0-$(( ${#INST_ARRAY[@]} - 1 ))." >&2
+  exit 1
+fi
+
+if [ "$SLURM_ARRAY_TASK_ID" -ge "${#INST_ARRAY[@]}" ]; then
+  echo "Array index $SLURM_ARRAY_TASK_ID exceeds instance list (${#INST_ARRAY[@]})." >&2
+  exit 1
+fi
+
+INSTANCE=${INST_ARRAY[$SLURM_ARRAY_TASK_ID]}
+OUTPUT_DIR=${OUTPUT_ROOT}/${INSTANCE}/10k
+mkdir -p "$OUTPUT_DIR" logs
+
+export JULIA_NUM_THREADS=${NPROCS}
+
+srun --nodes=${SLURM_NNODES:-1} \
+     --ntasks=1 \
+     --ntasks-per-node=1 \
+     --cpus-per-task=${NPROCS} \
+  julia --project acopf_gen_parallel.jl \
+    --instance=${INSTANCE} \
+    --n_scenarios=${SCENARIOS_PER_INSTANCE} \
+    --chunk_size=${CHUNK_SIZE} \
+    --nprocs=${NPROCS} \
+    --output_dir=${OUTPUT_DIR} \
+    --solver=${SOLVER}
+
+# Edit SBATCH account/qos/time/nodes and set array (example for 4 instances):
+# sbatch --array=0-3 scripts/perlmutter_acopf_10k_cpu.sl
+# Run for a specific set of instances (override INSTANCES):
+# INSTANCES="case89pegase,case162_ieee_dtc" sbatch --array=0-1 scripts/perlmutter_acopf_10k_cpu.sl


### PR DESCRIPTION
Resolved #7

The script can do:

- running on multiple Perlmutter CPU nodes,
- checkpointing the sample generation status and resuming.

Currently, 10K samples are generated on Perlmutter.
